### PR TITLE
Remove rm statuses.

### DIFF
--- a/status.json
+++ b/status.json
@@ -24,15 +24,11 @@
     "type": 0
   },
   {
-    "name": "rm -rf /",
-    "type": 0
-  },
-  {
     "name": "Emacs",
     "type": 0
   },
   { 
-    "name": "rm -rf $PREFIX",
+    "name": "sl^C^C^C^C^C",
     "type": 0
   },
   {


### PR DESCRIPTION
We had someone run the termux-specific one without thinking today, and while that's obviously user error, these statuses are seen in a place where there's really no baseline level of technical sophistication.

I have offered what I hope is a worthy substitute in their place.