### PR TITLE
commands(pkg): add `glibc` repo as valid repository

### DIFF
--- a/commands/pkg.lua
+++ b/commands/pkg.lua
@@ -10,7 +10,7 @@ local function getDownloadURL(repo, filename)
     return string.format("https://tur.kcubeterm.com/%s", filename)
   end
 
-  return string.format("https://grimler.se/termux-%s/%s", repo, filename)
+  return string.format("https://packages-cf.termux.dev/apt/termux-%s/%s", repo, filename)
 end
 
 local function getURL(repo, arch)
@@ -23,7 +23,7 @@ local function getURL(repo, arch)
   if repo == "x11" then dir = {"x11", "main"} end
   if repo == "root" then dir = {"root", "stable"} end
 
-  return string.format("https://grimler.se/termux-%s/dists/%s/%s/binary-%s/Packages", repo, dir[1], dir[2], arch)
+  return string.format("https://packages-cf.termux.dev/apt/termux-%s/dists/%s/%s/binary-%s/Packages", repo, dir[1], dir[2], arch)
 end
 
 -- Fetch the package index for the given repo and arch.

--- a/commands/pkg.lua
+++ b/commands/pkg.lua
@@ -22,6 +22,7 @@ local function getURL(repo, arch)
   
   if repo == "x11" then dir = {"x11", "main"} end
   if repo == "root" then dir = {"root", "stable"} end
+  if repo == "glibc" then dir = { "glibc", "stable" } end
 
   return string.format("https://packages-cf.termux.dev/apt/termux-%s/dists/%s/%s/binary-%s/Packages", repo, dir[1], dir[2], arch)
 end
@@ -101,8 +102,9 @@ local function pkgCommand(msg, args, meta)
   local repo = (args[2] or "main"):lower()
   local arch = (args[3] or "aarch64"):lower()
 
-  if repo ~= "main" and repo ~= "x11" and repo ~= "root" and repo ~= "tur" then
-    return "Invalid repository given.\n\nValid values include: main, x11, root, tur"
+  local valid_repos = { main = true, x11 = true, root = true, glibc = true, tur = true }
+  if valid_repos[repo] ~= true then
+    return "Invalid repository given.\n\nValid values include: main, x11, root, glibc, tur"
   end
 
   if arch ~= "all" and arch ~= "arm" and arch ~= "aarch64" and arch ~= "x86_64" and arch ~= "i686" then


### PR DESCRIPTION
This PR adds the `glibc` repo as a valid repository for the `!pkg` command.

Grimler's mirror doesn't host a mirror of it, but the origin repository at `packages-cf.termux.dev` does, so I have switched out the URL in `getDownloadURL()` and `getURL()`

I've also taken the liberty to turn the repo name validation into a table lookup instead of the previous abomination.

We could enumerate the valid repositories for the error reply from that table as well,
but I didn't wanna get too fancy for this PR.
I plan to do some follow up regarding code cleanup and establishing a consistent code style across the termux-bot codebase at a later time so that will be left well enough alone for now.